### PR TITLE
Fixed pulling installed fonts on Windows, small README clarity fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Certainly the process is different on Windows (perhaps try clicking the files in
 
 With a terminal open with a working directory in this project's folder, try `python3 bin/generate_card.py --help`.
 
-Example command to make a card: `python3 data/test/degraded_shockwave.json degraded_shockwave.png`.
+Example command to make a card: `python3 bin/generate_card.py data/test/degraded_shockwave.json degraded_shockwave.png`.
 This command will create the `degraded_shockwave.png` file in your current folder.
 
 Breakdown of other possibilities:

--- a/bin/generate_card.py
+++ b/bin/generate_card.py
@@ -16,8 +16,6 @@ from psd_tools import PSDImage
 from psd_tools.api.layers import PixelLayer
 from psd_tools.compression import Compression
 
-sys.path.insert(0,'%LocalAppData%/Microsoft/Windows/Fonts')
-
 # Constants
 COLOR_TITLE = "#000000"
 COLOR_COST = COLOR_TITLE
@@ -60,7 +58,7 @@ def find_font(name,size):
         joined_path = os.path.join(os.path.expandvars('%LocalAppData%/Microsoft/Windows/Fonts'),name)
         if os.path.isfile(joined_path):
             return PIL.ImageFont.truetype(joined_path,size)
-        else :
+        else:
             return PIL.ImageFont.truetype(name,size)
     else:
         return PIL.ImageFont.truetype(name,size)

--- a/bin/generate_card.py
+++ b/bin/generate_card.py
@@ -25,11 +25,11 @@ COLOR_DEFENSE = "#a1e3ee"
 COLOR_KEYWORD = "#efd521"
 COLORIZE_MIDPOINT = 127
 
-TITLE_TEXT_FONT = 'NanumMyeongjo.ttf'
+TITLE_TEXT_FONT = 'P22 Johnston Underground Regular.ttf'
 TITLE_TEXT_SIZE = 40
-DESC_TEXT_FONT = 'arial.ttf'
+DESC_TEXT_FONT = 'NotoSansDisplay-SemiCondensed.ttf'
 DESC_TEXT_SIZE = 32
-COST_TEXT_FONT = 'NanumMyeongjo.ttf'
+COST_TEXT_FONT = 'P22 Johnston Underground Regular.ttf'
 COST_TEXT_SIZE = 146
 
 TEXT_LEFT = 550

--- a/bin/generate_card.py
+++ b/bin/generate_card.py
@@ -16,6 +16,8 @@ from psd_tools import PSDImage
 from psd_tools.api.layers import PixelLayer
 from psd_tools.compression import Compression
 
+sys.path.insert(0,'%LocalAppData%/Microsoft/Windows/Fonts')
+
 # Constants
 COLOR_TITLE = "#000000"
 COLOR_COST = COLOR_TITLE
@@ -25,11 +27,11 @@ COLOR_DEFENSE = "#a1e3ee"
 COLOR_KEYWORD = "#efd521"
 COLORIZE_MIDPOINT = 127
 
-TITLE_TEXT_FONT = 'P22 Johnston Underground Regular.ttf'
+TITLE_TEXT_FONT = 'NanumMyeongjo.ttf'
 TITLE_TEXT_SIZE = 40
-DESC_TEXT_FONT = 'NotoSansDisplay-SemiCondensed.ttf'
+DESC_TEXT_FONT = 'arial.ttf'
 DESC_TEXT_SIZE = 32
-COST_TEXT_FONT = 'P22 Johnston Underground Regular.ttf'
+COST_TEXT_FONT = 'NanumMyeongjo.ttf'
 COST_TEXT_SIZE = 146
 
 TEXT_LEFT = 550
@@ -52,6 +54,16 @@ MINI_DOWN = 700
 
 PSD_NAME = 'lor_template.psd'
 PSD_MD5 = '53ed4a18dbd596add12463898e6a95bd'
+
+def find_font(name,size):
+    if os.name=="nt":
+        joined_path = os.path.join(os.path.expandvars('%LocalAppData%/Microsoft/Windows/Fonts'),name)
+        if os.path.isfile(joined_path):
+            return PIL.ImageFont.truetype(joined_path,size)
+        else :
+            return PIL.ImageFont.truetype(name,size)
+    else:
+        return PIL.ImageFont.truetype(name,size)
 
 def init_data(parent_dir, file_path):
     path = os.path.join(parent_dir, file_path)
@@ -215,7 +227,7 @@ def add_title(img, data):
     # To be safe, just create an image the size of the original
     text_layer = PIL.Image.new('RGBA', (img.width, img.height), color=(0,0,0,0))
     draw = PIL.ImageDraw.Draw(text_layer)
-    font = PIL.ImageFont.truetype(TITLE_TEXT_FONT, TITLE_TEXT_SIZE)
+    font = find_font(TITLE_TEXT_FONT, TITLE_TEXT_SIZE)
 
     center = ( TITLE_CENTER_X, TITLE_CENTER_Y )
     draw.multiline_text( center,
@@ -233,7 +245,7 @@ def add_title(img, data):
 
 def add_cost( asset_path, img, data ):
     draw = PIL.ImageDraw.Draw( img )
-    font = PIL.ImageFont.truetype( COST_TEXT_FONT, COST_TEXT_SIZE )
+    font = find_font( COST_TEXT_FONT, COST_TEXT_SIZE )
 
     cost_grit_path, cost_grit_stroke_fill = {
             'paperback' : ('cost_grit_paperback.png', '#9FE195'),
@@ -424,7 +436,7 @@ def wrap_keywords( draw, font, keywords, width ):
 
 def add_text( asset_path, keyword_data, img, data ):
     draw = PIL.ImageDraw.Draw( img )
-    font = PIL.ImageFont.truetype( DESC_TEXT_FONT, DESC_TEXT_SIZE )
+    font = find_font( DESC_TEXT_FONT, DESC_TEXT_SIZE )
     font_ascent, font_descent = font.getmetrics()
 
     # First, add the preamble, if it exists


### PR DESCRIPTION
Hey !

I've been struggling to use the custom fonts with PIL on Windows so I've created a small fix for it that should only impact Windows and should allow the use of both user-installed and pre-installed fonts by name.

I've also edited the example code line in the README that didn't mention the python file, which might confuse unexperienced users.

Tell me what you think !